### PR TITLE
Fix installing tox

### DIFF
--- a/bin/install-python.sh
+++ b/bin/install-python.sh
@@ -41,5 +41,6 @@ do
     if ! "$(pyenv root)/versions/$python_version/bin/tox" --version > /dev/null 2>&1
     then
         "$(pyenv root)/versions/$python_version/bin/pip" install --quiet --disable-pip-version-check tox > /dev/null
+        pyenv rehash
     fi
 done < .python-version

--- a/bin/replay_cookie_cutter.py
+++ b/bin/replay_cookie_cutter.py
@@ -43,7 +43,7 @@ class CookieCutter:
 
         temp_dir = mkdtemp()
 
-        try:
+        try:  # pylint:disable=too-many-try-statements
             project_name = cls.render_template(temp_dir, config, template)
             current_name = os.path.basename(project_dir)
 

--- a/src/superdev/project.py
+++ b/src/superdev/project.py
@@ -53,7 +53,7 @@ class Project:
         return status
 
     def _update_tox(self, status):
-        try:
+        try:  # pylint:disable=too-many-try-statements
             if self.tox_init:
                 for env in self.tox_init:
                     self._report(f"Initialising tox env '{env}'...")


### PR DESCRIPTION
Our scripting automatically installs tox in pyenv so you don't have to
install tox manually or system-wide. Unfortunately it wasn't working:
the installed tox doesn't appear on your PATH until you run a
`pyenv rehash`